### PR TITLE
Per-instructor package pricing with global fallback

### DIFF
--- a/Controller/booking/instructors/InstructorsBookingCotroller.js
+++ b/Controller/booking/instructors/InstructorsBookingCotroller.js
@@ -155,14 +155,19 @@ exports.instructorsByPostcodeAndAvailableTimeAndGearBox = async (req, res) => {
 ////////////////////// get Booking   //////////////////
 exports.getBookingPackagesByPostcodeAndtype = async (req, res) => {
     try {
-        const { postcode, type: typeId, packageId } = req.query;
+        const { postcode, type: typeId, packageId, instructorId } = req.query;
 
         if (!postcode) {
             return res.status(404).json({ message: 'Postcode is not defined.' });
         }
 
+        let instructor = null;
+        if (instructorId) {
+            instructor = await InstructorsUserSchema.findById(instructorId).catch(() => null);
+        }
+
         // Directly fetch and format booking packages based on the provided parameters
-        const formattedData = await fetchAndFormatBookingPackages(postcode, typeId, packageId);
+        const formattedData = await fetchAndFormatBookingPackages(postcode, typeId, packageId, instructor);
 
         // Create a new InstructorsSchema instance with the formatted data and save it
         const bookingInstructor = new InstructorsSchema(formattedData);
@@ -186,7 +191,7 @@ function sortDataByNumberHour(formattedData) {
     return formattedData;
 }
 
-async function fetchAndFormatBookingPackages(postcode, typeId, packageId) {
+async function fetchAndFormatBookingPackages(postcode, typeId, packageId, instructor) {
     let formattedData;
 
     if (packageId) {
@@ -195,7 +200,7 @@ async function fetchAndFormatBookingPackages(postcode, typeId, packageId) {
         if (!bookingPackage) {
             throw new Error("No booking package found for the given packageId and postcode.");
         }
-        formattedData = formatDataForBooking([bookingPackage]); // Format single package
+        formattedData = formatDataForBooking([bookingPackage], instructor); // Format single package
     } else if (typeId) {
         // Fetch booking packages by type and postcode
         const targetTypeOfLesson = await fetchLessonTypeById(typeId);
@@ -206,7 +211,7 @@ async function fetchAndFormatBookingPackages(postcode, typeId, packageId) {
         if (!bookingPackages.length) {
             throw new Error("No booking packages found for the given postcode and type.");
         }
-        formattedData = formatDataForBooking(bookingPackages); // Format multiple packages
+        formattedData = formatDataForBooking(bookingPackages, instructor); // Format multiple packages
     } else {
         throw new Error('Either type or packageId must be provided.');
     }
@@ -246,7 +251,30 @@ const fetchBookingPackages = async (postcode, slugOfTypeLesson) => {
     });
 };
 
-const formatDataForBooking = (bookingPackages) => {
+const resolvePackagePricing = (curr, instructor) => {
+    const hours = parseInt(curr.numberHour);
+
+    if (instructor && instructor.pricingMode === 'custom' && Array.isArray(instructor.customPackages)) {
+        const match = instructor.customPackages.find(
+            (p) => parseInt(p.numberHour) === hours && p.status !== 'inactive' && p.price > 0
+        );
+        if (match) {
+            const before = match.priceBeforeSale > match.price ? match.priceBeforeSale : match.price;
+            return { total: match.price, totalBeforeSale: before };
+        }
+    }
+
+    if (instructor && instructor.lessonHourlyRate > 0) {
+        const total = instructor.lessonHourlyRate * hours;
+        return { total, totalBeforeSale: total };
+    }
+
+    const total = convertToNumber(curr.price, "price");
+    const totalBeforeSale = convertToNumber(curr.priecBeforeSele, "priecBeforeSele");
+    return { total, totalBeforeSale };
+};
+
+const formatDataForBooking = (bookingPackages, instructor) => {
     const order = { 'manual': 1, 'automatic': 2, 'electric': 3 };
 
     // Check if 'manual' exists in the booking packages
@@ -273,12 +301,11 @@ const formatDataForBooking = (bookingPackages) => {
         }
 
         console.log(`curr ${curr.title}`);
-        const total = convertToNumber(curr.price, "price");
-        const totalBeforeSale = convertToNumber(curr.priecBeforeSele, "priecBeforeSele");
+        const { total, totalBeforeSale } = resolvePackagePricing(curr, instructor);
 
         // Calculate the savings
         const savings = totalBeforeSale - total;
-        const savingsPercentage = (savings / totalBeforeSale) * 100;
+        const savingsPercentage = totalBeforeSale > 0 ? (savings / totalBeforeSale) * 100 : 0;
 
         acc[curr.slugOfGearbox].packages.push({
             packageId: curr.id,

--- a/model/user/Instructor.js
+++ b/model/user/Instructor.js
@@ -204,6 +204,27 @@ const InstructorSchema = new mongoose.Schema(
         hourlyCost: {
             type: Number,
         },
+        pricingMode: {
+            type: String,
+            enum: ['hourly', 'custom'],
+            default: 'hourly',
+        },
+        lessonHourlyRate: {
+            type: Number,
+        },
+        customPackages: [
+            {
+                name: { type: String },
+                numberHour: { type: Number },
+                price: { type: Number },
+                priceBeforeSale: { type: Number },
+                status: {
+                    type: String,
+                    enum: ['active', 'inactive'],
+                    default: 'active',
+                },
+            },
+        ],
         areas: {
             type: Array,
             default: [],

--- a/scripts/backfillInstructorRates.js
+++ b/scripts/backfillInstructorRates.js
@@ -1,0 +1,77 @@
+const mongoose = require('mongoose');
+const Instructor = require('../model/user/Instructor');
+const BookingPackage = require('../model/booking/package/packageSchema');
+
+const areaLength = (postcode) => {
+  switch ((postcode || '').length) {
+    case 2: return 2;
+    case 3: return 3;
+    case 4: return 4;
+    case 5: return 2;
+    case 6: return 3;
+    case 7: return 4;
+    default: return 3;
+  }
+};
+
+const toNumber = (value) => {
+  if (!value) return NaN;
+  return parseFloat(String(value).replace(/,/g, '').replace(/\.+(?=\d*\.)/g, ''));
+};
+
+const computeAverageHourlyRate = (instructor, packages) => {
+  const gearbox = (instructor.gearbox || '').toLowerCase();
+  const areas = (instructor.areas || []).map((a) => String(a).toLowerCase());
+
+  const perHourRates = packages
+    .filter((p) => {
+      const slug = (p.slugOfGearbox || '').toLowerCase();
+      const gearboxMatches = slug === 'all' || (gearbox && gearbox.includes(slug));
+      if (!gearboxMatches) return false;
+      const prefixes = (p.postCode || [])
+        .map((x) => (x.postCode || '').slice(0, areaLength(x.postCode)).toLowerCase())
+        .filter(Boolean);
+      return prefixes.some((prefix) => areas.includes(prefix));
+    })
+    .map((p) => toNumber(p.price) / parseInt(p.numberHour))
+    .filter((n) => Number.isFinite(n) && n > 0);
+
+  if (!perHourRates.length) return null;
+  const average = perHourRates.reduce((a, b) => a + b, 0) / perHourRates.length;
+  return Math.round(average);
+};
+
+(async () => {
+  const dryRun = process.argv.includes('--dry-run');
+  await mongoose.connect(process.env.DATABASE, { useNewUrlParser: true, useUnifiedTopology: true });
+
+  const packages = await BookingPackage.find({ status: 'active' }).lean();
+  const instructors = await Instructor.find({ status: 'active' });
+
+  let set = 0;
+  let skippedExisting = 0;
+  let noMatchingPackages = 0;
+
+  for (const instructor of instructors) {
+    if (typeof instructor.lessonHourlyRate === 'number' && instructor.lessonHourlyRate > 0) {
+      skippedExisting += 1;
+      continue;
+    }
+    const rate = computeAverageHourlyRate(instructor, packages);
+    if (rate == null) {
+      noMatchingPackages += 1;
+      console.log(`SKIP (no matching global packages): ${instructor.firstName} ${instructor.lastName} areas=${JSON.stringify(instructor.areas)} gearbox=${instructor.gearbox}`);
+      continue;
+    }
+    console.log(`${dryRun ? '[dry-run] ' : ''}SET ${instructor.firstName} ${instructor.lastName} -> £${rate}/h (areas=${JSON.stringify(instructor.areas)}, gearbox=${instructor.gearbox})`);
+    if (!dryRun) {
+      instructor.lessonHourlyRate = rate;
+      instructor.pricingMode = 'hourly';
+      await instructor.save();
+      set += 1;
+    }
+  }
+
+  console.log(`\nDone. set=${set} skippedExisting=${skippedExisting} noMatchingPackages=${noMatchingPackages} dryRun=${dryRun}`);
+  await mongoose.disconnect();
+})().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

Adds per-instructor package pricing to the booking API, with a safe fallback to the existing global pricing. This backs the Driving School Diary move to independent instructors who set their own lesson prices.

## Changes

- **`model/user/Instructor.js`**: new fields `lessonHourlyRate` (Number), `pricingMode` (`'hourly' | 'custom'`, default `'hourly'`), and `customPackages`.
- **`Controller/booking/instructors/InstructorsBookingCotroller.js`**: `GET /booking/packages` now accepts an optional `instructorId`. A new `resolvePackagePricing` helper selects the price source in order — the instructor's custom package → the instructor's hourly rate (`total = rate × hours`) → the existing global package price. The response shape is unchanged.
- **`scripts/backfillInstructorRates.js`**: idempotent migration that back-fills `lessonHourlyRate` for instructors that don't yet have one, derived from the average per-hour of the global packages for their area and gearbox. Supports `--dry-run`.

## Behaviour & compatibility

Fully backward-compatible. Requests without `instructorId`, or instructors without a rate, return the current global pricing, and the response shape is unchanged — so this can ship ahead of the frontend with no visible effect.

## Testing

Verified against the DSD database: without an instructor the endpoint returns global prices; with an instructor at £35/h it returns 2h £70 / 10h £350 / 20h £840. The pricing helper was unit-checked across custom, hourly, and fallback cases, and the back-fill migration was verified idempotent.

## Notes

Targets `main` (the deploy branch). Consumed by the website's instructor-first booking flow (separate PR on the website repo).
